### PR TITLE
Make non-modal version actually work

### DIFF
--- a/debugger_no_modal.py
+++ b/debugger_no_modal.py
@@ -1,3 +1,4 @@
+import sys
 import os
 
 generatedDir = "generated"
@@ -95,7 +96,9 @@ def generate_response(system_prompt, user_prompt, model="gpt-3.5-turbo", *args):
 
 
 if __name__ == "__main__":
-    import sys
-
+    if len(sys.argv) < 2:
+        print("Please provide a prompt")
+        sys.exit(1)
     prompt = sys.argv[1]
-    main(prompt)
+    model = sys.argv[2] if len(sys.argv) > 2 else "gpt-3.5-turbo"
+    main(prompt, model)

--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -6,8 +6,6 @@ from time import sleep
 generatedDir = "generated"
 openai_model = "gpt-4"  # or 'gpt-3.5-turbo',
 openai_model_max_tokens = 2000  # i wonder how to tweak this properly
-retry = os.environ.get("RETRY", "false").lower() == "true"
-
 
 def generate_response(system_prompt, user_prompt, *args):
     import openai

--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -122,7 +122,7 @@ def main(prompt, directory=generatedDir, file=None):
     # a prompt for reading the currently open page and generating some response from openai
 
     # call openai api with this prompt
-    filepaths_string = generate_response.call(
+    filepaths_string = generate_response(
         """You are an AI developer who is trying to write a program that will generate code for the user based on their intent.
         
     When given their intent, create a complete, exhaustive list of filepaths that the user would write to make the program.

--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -71,34 +71,34 @@ def generate_file(
     # call openai api with this prompt
     filecode = generate_response(
         f"""You are an AI developer who is trying to write a program that will generate code for the user based on their intent.
-        
+
     the app is: {prompt}
 
     the files we have decided to generate are: {filepaths_string}
 
     the shared dependencies (like filenames and variable names) we have decided on are: {shared_dependencies}
-    
+
     only write valid code for the given filepath and file type, and return only the code.
     do not add any other explanation, only return valid code for that file type.
     """,
         f"""
-    We have broken up the program into per-file generation. 
-    Now your job is to generate only the code for the file {filename}. 
+    We have broken up the program into per-file generation.
+    Now your job is to generate only the code for the file {filename}.
     Make sure to have consistent filenames if you reference other files we are also generating.
-    
-    Remember that you must obey 3 things: 
+
+    Remember that you must obey 3 things:
        - you are generating code for the file {filename}
        - do not stray from the names of the files and the shared dependencies we have decided on
        - MOST IMPORTANT OF ALL - the purpose of our app is {prompt} - every line of code you generate must be valid code. Do not include code fences in your response, for example
-    
+
     Bad response:
-    ```javascript 
+    ```javascript
     console.log("hello world")
     ```
-    
+
     Good response:
     console.log("hello world")
-    
+
     Begin generating the code now.
 
     """,
@@ -124,10 +124,10 @@ def main(prompt, directory=generatedDir, file=None):
     # call openai api with this prompt
     filepaths_string = generate_response(
         """You are an AI developer who is trying to write a program that will generate code for the user based on their intent.
-        
+
     When given their intent, create a complete, exhaustive list of filepaths that the user would write to make the program.
-    
-    only list the filepaths you would write, and return them as a python list of strings. 
+
+    only list the filepaths you would write, and return them as a python list of strings.
     do not add any other explanation, only return a python list of strings.
     """,
         prompt,
@@ -160,13 +160,13 @@ def main(prompt, directory=generatedDir, file=None):
             # understand shared dependencies
             shared_dependencies = generate_response(
                 """You are an AI developer who is trying to write a program that will generate code for the user based on their intent.
-                
+
             In response to the user's prompt:
 
             ---
             the app is: {prompt}
             ---
-            
+
             the files we have decided to generate are: {filepaths_string}
 
             Now that we have a list of files, we need to understand what dependencies they share.

--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -237,9 +237,6 @@ if __name__ == "__main__":
         print("Please provide a prompt")
         sys.exit(1)
     prompt = sys.argv[1]
-    directory = generatedDir
-    if len(sys.argv) > 2:
-        directory = sys.argv[2]
-    if len(sys.argv) > 3:
-        file = sys.argv[3]
+    directory = sys.argv[2] if len(sys.argv) > 2 else generatedDir
+    file = sys.argv[3] if len(sys.argv) > 3 else None
     main(prompt, directory, file)

--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -177,9 +177,9 @@ def main(prompt, directory=generatedDir, file=None):
             # write shared dependencies as a md file inside the generated directory
             write_file("shared_dependencies.md", shared_dependencies, directory)
 
-            for filename in list_actual:
-                filecode = generate_file(
-                    filename,
+            for name in list_actual:
+                filename, filecode = generate_file(
+                    name,
                     filepaths_string=filepaths_string,
                     shared_dependencies=shared_dependencies,
                     prompt=prompt,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-modal-client
 openai
 tiktoken


### PR DESCRIPTION
There was quite a couple issues with the non-modal version merged in PR #11.
- There was a stray `.call` to a function that was originally wrapped by Modal, which has been removed.
- The `file` variable passed to main would cause the script would crash if a file wasn't passed.
- The `filecode` variable used to write the results of each file's code was improperly set as a tuple rather than a str, which would crash the script because there would be a type mismatch when calling `write_file`.

I've also removed a couple of miscellaneous things that aren't used anywhere:
- There was a retry variable that was not actually being considered when retrying.
- `modal-client` is a specified as a dependency in `requirements.txt` despite being a whole different way to run the app; if you use Modal, you shouldn't need `requirements.txt` at all since you install things through Modal!