### PR TITLE
Added .devcontainer for simplified development setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,13 @@
 {
-    "name": "Python Project",
-    "dockerFile": "Dockerfile",
+    "name": "Python Project", // The name of your dev container setup, can be anything you choose.
+    "dockerFile": "Dockerfile", // The path to the Dockerfile that describes your development environment.
     "settings": { 
-        "terminal.integrated.shell.linux": "/bin/bash",
-        "python.pythonPath": "/usr/local/bin/python",
-        "python.linting.pylintEnabled": true,
-        "python.linting.enabled": true
+        "terminal.integrated.shell.linux": "/bin/bash", // Specifies the shell to be used in the integrated terminal in VS Code.
+        "python.pythonPath": "/usr/local/bin/python", // Specifies the path to the Python interpreter.
+        "python.linting.pylintEnabled": true, // Enables linting using pylint for Python files.
+        "python.linting.enabled": true // Enables linting for Python files in general.
     },
-    "extensions": ["ms-python.python"],
-    "forwardPorts": [],
-    "postCreateCommand": "pip install -r requirements.txt"
+    "extensions": ["ms-python.python"], // Specifies VS Code extensions that should be installed in the dev container when it is created, in this case, the Microsoft Python extension.
+    "forwardPorts": [], // Specifies any ports that should be forwarded from the dev container to the host.
+    "postCreateCommand": "pip install -r requirements.txt" // Specifies a command or series of commands to run after the dev container is created.
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "Python Project",
+    "dockerFile": "Dockerfile",
+    "settings": { 
+        "terminal.integrated.shell.linux": "/bin/bash",
+        "python.pythonPath": "/usr/local/bin/python",
+        "python.linting.pylintEnabled": true,
+        "python.linting.enabled": true
+    },
+    "extensions": ["ms-python.python"],
+    "forwardPorts": [],
+    "postCreateCommand": "pip install -r requirements.txt"
+}

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,6 +1,11 @@
-# syntax=docker/dockerfile:1
-FROM python:3.9-slim-buster
-WORKDIR /app
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-COPY . .
+# syntax=docker/dockerfile:1   # Specifies Dockerfile version to use. In this case, version 1.
+
+FROM python:3.9-slim-buster   # Defines the base image to use for your Docker image. Here, it's the slim-buster version of the official Python 3.9 image.
+
+WORKDIR /app   # Sets the working directory in the Docker container. Any command that follows in the Dockerfile will be run in this directory.
+
+COPY requirements.txt .  # Copies the requirements.txt file from your project to the working directory in the Docker image.
+
+RUN pip install -r requirements.txt  # Runs pip install command in your Docker image to install Python dependencies listed in your requirements.txt file.
+
+COPY . .  # Copies everything else in your project (denoted by '.') to the working directory in the Docker image.

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+FROM python:3.9-slim-buster
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,38 @@ modal run main.py --prompt code2prompt-gpt4.md --directory code2prompt2code
 
 We leave the social and technical impacts of multilayer generative deep-frying of codebases as an exercise to the reader.
 
+## Development using a Dev Container
+
+We have configured a development container for this project, which provides an isolated and consistent development environment. This approach is ideal for developers using Visual Studio Code's Remote - Containers extension or GitHub's Codespaces.
+
+### Benefits of a Dev Container
+
+1. **Consistent Environment**: Every developer works within the same development setup, eliminating "it works on my machine" issues and easing the onboarding of new contributors.
+
+2. **Sandboxing**: Your development environment is isolated from your local machine, allowing you to work on multiple projects with differing dependencies without conflict.
+
+3. **Version Control for Environments**: Just as you version control your source code, you can do the same with your development environment. If a dependency update introduces issues, it's easy to revert to a previous state.
+
+4. **Easier CI/CD Integration**: If your CI/CD pipeline utilizes Docker, your testing environment will be identical to your local development environment, ensuring consistency across development, testing, and production setups.
+
+5. **Portability**: This setup can be utilized on any computer with Docker and the appropriate IDE installed. Simply clone the repository and start the container.
+
+### Using the Dev Container
+
+To start using the dev container, follow these steps:
+
+1. Install Docker on your machine.
+
+2. Install the 'Remote - Containers' extension in Visual Studio Code.
+
+3. Clone the repository.
+
+4. Open the project in Visual Studio Code. When prompted, click on "Reopen in Container". 
+
+   Alternatively, you can use the Command Palette (View > Command Palette...). Type 'Remote-Containers: Open Folder in Container...' and select the cloned repository folder.
+
+5. The development container should start, and you'll be placed inside the container with all the tools and dependencies already set up.
+
 ## future directions
 
 things to try/would accept open issue discussions and PRs:

--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,16 @@ We leave the social and technical impacts of multilayer generative deep-frying o
 
 We have configured a development container for this project, which provides an isolated and consistent development environment. This approach is ideal for developers using Visual Studio Code's Remote - Containers extension or GitHub's Codespaces.
 
+If you have [VS Code](https://code.visualstudio.com/download) and [Docker](https://www.docker.com/products/docker-desktop) installed on your machine, you can make use of the devcontainer to create an isolated environment with all dependencies automatically installed and configured. This is a great way to ensure a consistent development experience across different machines.
+
+Here are the steps to use the devcontainer:
+
+1. Open this project in VS Code.
+2. When prompted to "Reopen in Container", choose "Reopen in Container". This will start the process of building the devcontainer defined by the `Dockerfile` and `.devcontainer.json` in the `.devcontainer` directory.
+3. Wait for the build to finish. The first time will be a bit longer as it downloads and builds everything. Future loads will be much faster.
+4. Once the build is finished, the VS Code window will reload and you are now working inside the devcontainer.
+
+
 ### Benefits of a Dev Container
 
 1. **Consistent Environment**: Every developer works within the same development setup, eliminating "it works on my machine" issues and easing the onboarding of new contributors.
@@ -210,21 +220,6 @@ We have configured a development container for this project, which provides an i
 
 5. **Portability**: This setup can be utilized on any computer with Docker and the appropriate IDE installed. Simply clone the repository and start the container.
 
-### Using the Dev Container
-
-To start using the dev container, follow these steps:
-
-1. Install Docker on your machine.
-
-2. Install the 'Remote - Containers' extension in Visual Studio Code.
-
-3. Clone the repository.
-
-4. Open the project in Visual Studio Code. When prompted, click on "Reopen in Container". 
-
-   Alternatively, you can use the Command Palette (View > Command Palette...). Type 'Remote-Containers: Open Folder in Container...' and select the cloned repository folder.
-
-5. The development container should start, and you'll be placed inside the container with all the tools and dependencies already set up.
 
 ## future directions
 

--- a/readme.md
+++ b/readme.md
@@ -196,9 +196,11 @@ We leave the social and technical impacts of multilayer generative deep-frying o
 
 ## Development using a Dev Container
 
+> this is a [new addition](https://github.com/smol-ai/developer/pull/30)! Please try it out and send in fixes if there are any issues.
+
 We have configured a development container for this project, which provides an isolated and consistent development environment. This approach is ideal for developers using Visual Studio Code's Remote - Containers extension or GitHub's Codespaces.
 
-If you have [VS Code](https://code.visualstudio.com/download) and [Docker](https://www.docker.com/products/docker-desktop) installed on your machine, you can make use of the devcontainer to create an isolated environment with all dependencies automatically installed and configured. This is a great way to ensure a consistent development experience across different machines.
+If you have [VS Code](https://code.visualstudio.com/download) and [Docker](https://www.swyx.io/running-docker-without-docker-desktop) installed on your machine, you can make use of the devcontainer to create an isolated environment with all dependencies automatically installed and configured. This is a great way to ensure a consistent development experience across different machines.
 
 Here are the steps to use the devcontainer:
 
@@ -208,7 +210,8 @@ Here are the steps to use the devcontainer:
 4. Once the build is finished, the VS Code window will reload and you are now working inside the devcontainer.
 
 
-### Benefits of a Dev Container
+<details>
+<summary> Benefits of a Dev Container </summary>
 
 1. **Consistent Environment**: Every developer works within the same development setup, eliminating "it works on my machine" issues and easing the onboarding of new contributors.
 
@@ -219,6 +222,7 @@ Here are the steps to use the devcontainer:
 4. **Easier CI/CD Integration**: If your CI/CD pipeline utilizes Docker, your testing environment will be identical to your local development environment, ensuring consistency across development, testing, and production setups.
 
 5. **Portability**: This setup can be utilized on any computer with Docker and the appropriate IDE installed. Simply clone the repository and start the container.
+</details>
 
 
 ## future directions


### PR DESCRIPTION
In this merge request, I have added a `.devcontainer` directory with a `devcontainer.jso`n file and a `Dockerfile`. These files together allow for easier setup of the development environment, especially for developers using Visual Studio Code's Dev Container feature or GitHub's Codespaces.

The `devcontainer.json` file configures the dev container specifically for Python development in alignment with our project's needs. It sets the terminal shell, Python interpreter path, enables Python linting, specifies the required VS Code extensions, sets up port forwarding, and also defines the post creation command to install our project's Python dependencies. When a developer opens the project in a Dev Container, these settings are automatically applied.

The Dockerfile contains instructions to create a Docker image suitable for our project. It uses the Python 3.9 slim-buster image as its base, sets the working directory to /app, and copies over the project files.