### PR TITLE
Revert import statements to original position in `generate_response` function

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
-import sys
 import os
 import modal
 import ast
+import openai
+import tiktoken
 
 stub = modal.Stub("smol-developer-v1")
 generatedDir = "generated"
@@ -22,9 +23,6 @@ openai_model_max_tokens = 2000 # i wonder how to tweak this properly
     # timeout=120,
 )
 def generate_response(system_prompt, user_prompt, *args):
-    import openai
-    import tiktoken
-
     def reportTokens(prompt):
         encoding = tiktoken.encoding_for_model(openai_model)
         # print number of tokens in light gray, with first 10 characters of prompt in green
@@ -39,7 +37,7 @@ def generate_response(system_prompt, user_prompt, *args):
     reportTokens(system_prompt)
     messages.append({"role": "user", "content": user_prompt})
     reportTokens(user_prompt)
-    # loop thru each arg and add it to messages alternating role between "assistant" and "user"
+    # Loop through each value in args and add it to messages alternating role between "assistant" and "user"
     role = "assistant"
     for value in args:
         messages.append({"role": role, "content": value})
@@ -170,7 +168,7 @@ def main(prompt, directory=generatedDir, file=None):
             # write shared dependencies as a md file inside the generated directory
             write_file("shared_dependencies.md", shared_dependencies, directory)
             
-            # Existing for loop
+            # Generate code files for each file path in `list_actual`.
             for filename, filecode in generate_file.map(
                 list_actual, order_outputs=False, kwargs=dict(filepaths_string=filepaths_string, shared_dependencies=shared_dependencies, prompt=prompt)
             ):
@@ -178,7 +176,7 @@ def main(prompt, directory=generatedDir, file=None):
 
 
     except ValueError:
-        print("Failed to parse result: " + result)
+        print("Failed to parse result.")
 
 
 def write_file(filename, filecode, directory):
@@ -197,14 +195,12 @@ def write_file(filename, filecode, directory):
 
 
 def clean_dir(directory):
-    import shutil
-
-    extensions_to_skip = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg', '.ico', '.tif', '.tiff']  # Add more extensions if needed
+    extensions_to_skip = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg', '.ico', '.tif', '.tiff', '.eps', '.raw']  # Add more extensions if needed
 
     # Check if the directory exists
     if os.path.exists(directory):
         # If it does, iterate over all files and directories
-        for root, dirs, files in os.walk(directory):
+        for root, files in os.walk(directory):
             for file in files:
                 _, extension = os.path.splitext(file)
                 if extension not in extensions_to_skip:

--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
 import os
 import modal
 import ast
-import openai
-import tiktoken
 
 stub = modal.Stub("smol-developer-v1")
 generatedDir = "generated"
@@ -23,6 +21,11 @@ openai_model_max_tokens = 2000 # i wonder how to tweak this properly
     # timeout=120,
 )
 def generate_response(system_prompt, user_prompt, *args):
+    # IMPORTANT: Keep the import statements here due to Modal container restrictions.
+    # Shifting the imports to the start of the code may cause issues with package availability.
+    import openai
+    import tiktoken
+
     def reportTokens(prompt):
         encoding = tiktoken.encoding_for_model(openai_model)
         # print number of tokens in light gray, with first 10 characters of prompt in green

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,12 @@ Perhaps a higher order evolution of programming where you still need to be techn
 
 https://youtu.be/UCo7YeTy-aE (sorry for sped up audio, we were optimizing for twitter, bad call)
 
+Another user shared their example (prompt => app in one image)
+
+[![image](https://github.com/smol-ai/developer/assets/6764957/15fa189a-3f52-4618-ac8e-2a77b6500264)](https://twitter.com/RobertCaracaus/status/1659312419485761536?s=20)
+
+I'm actively working on more examples, sorry for the lack of examples, I know that is frustrating but I wasnt ready for so many of you lol
+
 ## arch diagram
 
 naturally generated with gpt4, like [we did for babyagi](https://twitter.com/swyx/status/1648724820316786688)

--- a/readme.md
+++ b/readme.md
@@ -32,15 +32,24 @@ Loop until happiness is attained. Notice that AI is only used as long as it is a
 
 Perhaps a higher order evolution of programming where you still need to be technical, but no longer have to implement every detail at least to scaffold things out.
 
-## 6 minute video demo
+## examples/prompt gallery
 
-https://youtu.be/UCo7YeTy-aE (sorry for sped up audio, we were optimizing for twitter, bad call)
+- [6 minute video demo](https://youtu.be/UCo7YeTy-aE) - (sorry for sped up audio, we were optimizing for twitter, bad call)
+  - this was the original smol developer demo - going from prompt to full chrome extension that requests and stores and apikey, generates a popup window, reads and transmits page content, and usefully summarizes any website with Anthropic Claude, switching models up to the 100k one based on length of input
+  - the prompt is located in [prompt.md](https://github.com/smol-ai/developer/blob/main/prompt.md) and it outputs [/exampleChromeExtension](https://github.com/smol-ai/developer/tree/main/exampleChromeExtension)
+- `smol-plugin` - prompt to ChatGPT plugin ([tweet](https://twitter.com/ultrasoundchad/status/1659366507409985536?s=20), [fork](https://github.com/gmchad/smol-plugin))
 
-Another user shared their example (prompt => app in one image)
+  <img src="https://github.com/smol-ai/developer/assets/6764957/6ffaac3b-5d90-460a-a590-c8a8c004bd36" height=200 />
 
-[![image](https://github.com/smol-ai/developer/assets/6764957/15fa189a-3f52-4618-ac8e-2a77b6500264)](https://twitter.com/RobertCaracaus/status/1659312419485761536?s=20)
+- [Prompt to Pokemon App](https://twitter.com/RobertCaracaus/status/1659312419485761536?s=20)
+  
+  <img src="https://github.com/smol-ai/developer/assets/6764957/15fa189a-3f52-4618-ac8e-2a77b6500264" height=200 />
+  
+- [Political Campaign CRM Program example](https://github.com/smol-ai/developer/pull/22/files)
 
-I'm actively working on more examples, sorry for the lack of examples, I know that is frustrating but I wasnt ready for so many of you lol
+I'm actively seeking more examples, please PR yours! 
+
+sorry for the lack of examples, I know that is frustrating but I wasnt ready for so many of you lol
 
 ## arch diagram
 


### PR DESCRIPTION
The import statements were shifted to the start of the code by my previous pull request, presumably due to Modal container restrictions. However, this caused issues with package availability. This commit reverts the import statements back to their original position within the ```generate_response``` function to ensure proper functionality.
