### PR TITLE
Fix: File Permission Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__
 
 # Don't ignore .png files in the generated directory
 !/generated/*.png
+
+.idea
+/.idea/

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import ast
 stub = modal.Stub("smol-developer-v1")
 generatedDir = "generated"
 openai_image = modal.Image.debian_slim().pip_install("openai", "tiktoken")
-openai_model = "gpt-4" # or 'gpt-3.5-turbo',
+openai_model = "gpt-3.5-turbo"
 openai_model_max_tokens = 2000 # i wonder how to tweak this properly
 
 
@@ -186,8 +186,14 @@ def write_file(filename, filecode, directory):
     print("\033[94m" + filename + "\033[0m")
     print(filecode)
     
-    file_path = directory + "/" + filename
+    file_path = os.path.join(directory, filename)
     dir = os.path.dirname(file_path)
+
+    # Check if the filename is actually a directory
+    if os.path.isdir(file_path):
+        print(f"Error: {filename} is a directory, not a file.")
+        return
+
     os.makedirs(dir, exist_ok=True)
 
     # Open the file in write mode

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import ast
 stub = modal.Stub("smol-developer-v1")
 generatedDir = "generated"
 openai_image = modal.Image.debian_slim().pip_install("openai", "tiktoken")
-openai_model = "gpt-3.5-turbo"
+openai_model = "gpt-4" # or 'gpt-3.5-turbo', but it's going to be worse at generating code so we strongly recommend gpt4. i know most people dont have access, we are working on a hosted version 
 openai_model_max_tokens = 2000 # i wonder how to tweak this properly
 
 


### PR DESCRIPTION
Updated to check if writing to file or directory, Saves time and don't have to write large complicated prompts, should normally sort itself out instead.

For example without this with a simple prompt it may try and write a single files code to a directory name, and get a Error 13: Permission error. Instead this will check if the file_path is a directory or a file first, it seems that the handler response is enough to trigger the AI to look inside the directory to write the multiple files it needs to, instead of treating a directory like a file and trying to save files or write files to it.

And also using os.path.join is standard for cross-platform forgot to add this point instead of manually setting it with directory + "/" + filename, Avoids uni-code conflicts. 

Just ignore the gitignore and parameter settings, you can just accept the update to the file system. 