### PR TITLE
Dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,28 @@
 {
-    "name": "Python Project", // The name of your dev container setup, can be anything you choose.
-    "dockerFile": "Dockerfile", // The path to the Dockerfile that describes your development environment.
-    "settings": { 
-        "terminal.integrated.shell.linux": "/bin/bash", // Specifies the shell to be used in the integrated terminal in VS Code.
-        "python.pythonPath": "/usr/local/bin/python", // Specifies the path to the Python interpreter.
-        "python.linting.pylintEnabled": true, // Enables linting using pylint for Python files.
-        "python.linting.enabled": true // Enables linting for Python files in general.
+    "name": "smol-developer", // The name of your dev container setup, can be anything you choose.
+    "build": {
+      "dockerfile": "dockerfile", // The path to the Dockerfile that describes your development environment.
+      "context": "..",
+      "args": { 
+        // Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+        // Append -bullseye or -buster to pin to an OS version.
+        // Use -bullseye variants on local on arm64/Apple Silicon.
+        "VARIANT": "3.9-buster",
+        // Options
+        "NODE_VERSION": "lts/*"
+      }
+    }, 
+    "customizations": {
+      "vscode": {
+        "extensions": ["ms-python.python"],
+        "settings": {
+          "terminal.integrated.shell.linux": "/bin/bash", // Specifies the shell to be used in the integrated terminal in VS Code.
+          "python.pythonPath": "/usr/local/bin/python", // Specifies the path to the Python interpreter.
+          "python.linting.pylintEnabled": true, // Enables linting using pylint for Python files.
+          "python.linting.enabled": true // Enables linting for Python files in general.]
+        }
+      }
     },
-    "extensions": ["ms-python.python"], // Specifies VS Code extensions that should be installed in the dev container when it is created, in this case, the Microsoft Python extension.
     "forwardPorts": [], // Specifies any ports that should be forwarded from the dev container to the host.
     "postCreateCommand": "pip install -r requirements.txt" // Specifies a command or series of commands to run after the dev container is created.
 }

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,11 +1,19 @@
 # syntax=docker/dockerfile:1   # Specifies Dockerfile version to use. In this case, version 1.
 
-FROM python:3.9-slim-buster   # Defines the base image to use for your Docker image. Here, it's the slim-buster version of the official Python 3.9 image.
+# Defines the base image to use for your Docker image. Here, it is the slim-buster version of the official Python 3.9 img
+FROM python:3.9-slim-buster
 
-WORKDIR /app   # Sets the working directory in the Docker container. Any command that follows in the Dockerfile will be run in this directory.
+# Sets the working directory in the Docker container. Any command that follows in the Dockerfile will be run in this directory
+WORKDIR /app
 
-COPY requirements.txt .  # Copies the requirements.txt file from your project to the working directory in the Docker image.
+# Copies the requirements.txt file from your project to the working directory in the Docker img
+COPY requirements.txt .
 
-RUN pip install -r requirements.txt  # Runs pip install command in your Docker image to install Python dependencies listed in your requirements.txt file.
+# Copies your .env file from your project to the working directory in the Docker img
+COPY .env .
 
-COPY . .  # Copies everything else in your project (denoted by '.') to the working directory in the Docker image.
+# Runs pip install command in your Docker image to install Python dependencies listed in your requirements.txt file
+RUN pip install -r requirements.txt
+
+# Copies everything else in your project (denoted by '.') to the working directory in the Docker img
+COPY . .

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -6,11 +6,8 @@ FROM python:3.9-slim-buster
 # Sets the working directory in the Docker container. Any command that follows in the Dockerfile will be run in this directory
 WORKDIR /app
 
-# Copies the requirements.txt file from your project to the working directory in the Docker img
-COPY requirements.txt .
-
-# Copies your .env file from your project to the working directory in the Docker img
-COPY .env .
+# Copies the requirements.txt and .env file from your project to the working directory in the Docker img
+COPY requirements.txt .env* ./
 
 # Runs pip install command in your Docker image to install Python dependencies listed in your requirements.txt file
 RUN pip install -r requirements.txt

--- a/code2prompt.py
+++ b/code2prompt.py
@@ -1,6 +1,10 @@
 import modal
 import os
 from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS, EXTENSION_TO_SKIP
+from dotenv import load_dotenv
+
+
+load_dotenv()
 
 stub = modal.Stub("smol-codetoprompt-v1")
 openai_image = modal.Image.debian_slim().pip_install("openai")

--- a/debugger.py
+++ b/debugger.py
@@ -1,6 +1,11 @@
 import modal
 import os
 from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS, EXTENSION_TO_SKIP
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
 
 stub = modal.Stub("smol-debugger-v1")
 openai_image = modal.Image.debian_slim().pip_install("openai")

--- a/debugger_no_modal.py
+++ b/debugger_no_modal.py
@@ -3,6 +3,12 @@ import os
 from time import sleep
 from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS, EXTENSION_TO_SKIP
 import argparse
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
 def read_file(filename):
     with open(filename, "r") as file:
         return file.read()

--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@ import modal
 import ast
 from utils import clean_dir
 from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS
+from dotenv import load_dotenv
+
+
+load_dotenv()
 
 stub = modal.Stub("smol-developer-v1") # yes we are recommending using Modal by default, as it helps with deployment. see readme for why.
 openai_image = modal.Image.debian_slim().pip_install("openai", "tiktoken")

--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -4,6 +4,11 @@ import ast
 from time import sleep
 from utils import clean_dir
 from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
 
 def generate_response(system_prompt, user_prompt, *args):
     import openai

--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,7 @@ Here are the steps to use the devcontainer:
 2. When prompted to "Reopen in Container", choose "Reopen in Container". This will start the process of building the devcontainer defined by the `Dockerfile` and `.devcontainer.json` in the `.devcontainer` directory.
 3. Wait for the build to finish. The first time will be a bit longer as it downloads and builds everything. Future loads will be much faster.
 4. Once the build is finished, the VS Code window will reload and you are now working inside the devcontainer.
-
+5. Note that you will need to use the no-modal version with the provided dockerfile (i.e. `python main_no_modal.py`).
 
 <details>
 <summary> Benefits of a Dev Container </summary>

--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,7 @@ Here are the steps to use the devcontainer:
 2. When prompted to "Reopen in Container", choose "Reopen in Container". This will start the process of building the devcontainer defined by the `Dockerfile` and `.devcontainer.json` in the `.devcontainer` directory.
 3. Wait for the build to finish. The first time will be a bit longer as it downloads and builds everything. Future loads will be much faster.
 4. Once the build is finished, the VS Code window will reload and you are now working inside the devcontainer.
-5. Note that you will need to use the no-modal version with the provided dockerfile (i.e. `python main_no_modal.py`). If you want to use modal, you'll have to run `pip install modal-client && modal token new` inside the container.
+5. Note that the provided dockerfile doesn't set up modal for you. If you want to use modal, you'll have to run `pip install modal-client && modal token new` inside the container.
 
 <details>
 <summary> Benefits of a Dev Container </summary>

--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,7 @@ Here are the steps to use the devcontainer:
 2. When prompted to "Reopen in Container", choose "Reopen in Container". This will start the process of building the devcontainer defined by the `Dockerfile` and `.devcontainer.json` in the `.devcontainer` directory.
 3. Wait for the build to finish. The first time will be a bit longer as it downloads and builds everything. Future loads will be much faster.
 4. Once the build is finished, the VS Code window will reload and you are now working inside the devcontainer.
-5. Note that you will need to use the no-modal version with the provided dockerfile (i.e. `python main_no_modal.py`).
+5. Note that you will need to use the no-modal version with the provided dockerfile (i.e. `python main_no_modal.py`). If you want to use modal, you'll have to run `pip install modal-client && modal token new` inside the container.
 
 <details>
 <summary> Benefits of a Dev Container </summary>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # if you are running the default variants (main.py, debugger.py, etc), you do not need to install these requirements
 openai
 tiktoken
+python-dotenv


### PR DESCRIPTION
Changes:

1. There's a bug in the VSCode devcontainers extension that causes it to fail to interpret end-of-line comments as comments in the dockerfile. This was causing Docker container build to fail. I moved the comments to their own lines, and it fixed the issue.

2. The .devcontainer.json file was incorrectly formatted, so I fixed the JSON hierarchy for "build" and "settings". (The terminal setting is still using a deprecated format, but I left that one because it's non-breaking and I wanted to leave a minimal footprint.)

3. I clarified in the README that the dockerfile doesn't set up modal, so you'll have to set up modal in the container yourself.

4. I added python-dotenv as a dependency and added load_dotenv() statements to the modules users can call.

5. I edited the dockerfile so that it optionally copies any .env file over to the Docker container.