### PR TITLE
fix(main_no_modal.py): load environment variables from .env file

### DIFF
--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -3,6 +3,7 @@ import os
 import ast
 from time import sleep
 from utils import clean_dir
+from dotenv import load_dotenv
 from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS
 
 def generate_response(system_prompt, user_prompt, *args):
@@ -104,6 +105,9 @@ def generate_file(
 
 
 def main(prompt, directory=DEFAULT_DIR, file=None):
+    # load .env file
+    load_dotenv()
+
     # read file from prompt if it ends in a .md filetype
     if prompt.endswith(".md"):
         with open(prompt, "r") as promptfile:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # if you are running the default variants (main.py, debugger.py, etc), you do not need to install these requirements
 openai
 tiktoken
+python-dotenv


### PR DESCRIPTION
This PR fixes an issue where the OPENAI_API_KEY variable wasn't being loaded from the .env file.

Resolves Issue #85.