### PR TITLE
feat: USE_FULL_PROJECT_PROMPT + extracting code from ```

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -2,6 +2,15 @@ import os
 
 EXTENSION_TO_SKIP = [".png",".jpg",".jpeg",".gif",".bmp",".svg",".ico",".tif",".tiff"]
 DEFAULT_DIR = "generated"
+
+try:
+    USE_FULL_PROJECT_PROMPT = bool(os.environ["USE_FULL_PROJECT_PROMPT"])
+except KeyError:
+    # If enabled for each file generation prompt we will include all the files generated before
+    # It helps to make code much more consistent
+    # But requires at least 16k context model even for a small project
+    USE_FULL_PROJECT_PROMPT = False
+
 # https://platform.openai.com/docs/models/gpt-4
 try:
     DEFAULT_MODEL = os.environ["OPENAI_DEFAULT_MODEL"]

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,15 @@
+import os
+
 EXTENSION_TO_SKIP = [".png",".jpg",".jpeg",".gif",".bmp",".svg",".ico",".tif",".tiff"]
 DEFAULT_DIR = "generated"
-DEFAULT_MODEL = "gpt-3.5-turbo" # we recommend 'gpt-4' if you have it # gpt3.5 is going to be worse at generating code so we strongly recommend gpt4. i know most people dont have access, we are working on a hosted version 
-DEFAULT_MAX_TOKENS = 2000 # i wonder how to tweak this properly. we dont want it to be max length as it encourages verbosity of code. but too short and code also truncates suddenly.
+# https://platform.openai.com/docs/models/gpt-4
+try:
+    DEFAULT_MODEL = os.environ["OPENAI_DEFAULT_MODEL"]
+except KeyError:
+    # we recommend 'gpt-4' if you have it # gpt3.5 is going to be worse at generating code so we strongly recommend gpt4. i know most people dont have access, we are working on a hosted version 
+    DEFAULT_MODEL = "gpt-3.5-turbo"
+try:
+    DEFAULT_MAX_TOKENS = int(os.environ["OPENAI_DEFAULT_MAX_TOKENS"])
+except KeyError:
+    # i wonder how to tweak this properly. we dont want it to be max length as it encourages verbosity of code. but too short and code also truncates suddenly.
+    DEFAULT_MAX_TOKENS = 2000

--- a/main_no_modal.py
+++ b/main_no_modal.py
@@ -1,9 +1,10 @@
 import sys
 import os
+import re
 import ast
 from time import sleep
 from utils import clean_dir
-from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS
+from constants import DEFAULT_DIR, DEFAULT_MODEL, DEFAULT_MAX_TOKENS, USE_FULL_PROJECT_PROMPT
 
 def generate_response(system_prompt, user_prompt, *args):
     import openai
@@ -62,7 +63,7 @@ def generate_response(system_prompt, user_prompt, *args):
 
 
 def generate_file(
-    filename, filepaths_string=None, shared_dependencies=None, prompt=None
+    filename, filepaths_string=None, shared_dependencies=None, prompt=None, generatedFilesContent=None
 ):
     # call openai api with this prompt
     filecode = generate_response(
@@ -72,8 +73,9 @@ def generate_file(
 
     the files we have decided to generate are: {filepaths_string}
 
-    the shared dependencies (like filenames and variable names) we have decided on are: {shared_dependencies}
-
+    the shared dependencies (like filenames and variable names) we have decided on are: {shared_dependencies}""" +
+    (f"already generated files are:\n {generatedFilesContent}" if (USE_FULL_PROJECT_PROMPT and generatedFilesContent) else "") +
+        f"""
     only write valid code for the given filepath and file type, and return only the code.
     do not add any other explanation, only return valid code for that file type.
     """,
@@ -100,7 +102,7 @@ def generate_file(
     """,
     )
 
-    return filename, filecode
+    return filename, get_code_from_string(filecode)
 
 
 def main(prompt, directory=DEFAULT_DIR, file=None):
@@ -174,7 +176,7 @@ def main(prompt, directory=DEFAULT_DIR, file=None):
             print(shared_dependencies)
             # write shared dependencies as a md file inside the generated directory
             write_file("shared_dependencies.md", shared_dependencies, directory)
-
+            generated_files_content = ""
             for name in list_actual:
                 filename, filecode = generate_file(
                     name,
@@ -183,10 +185,27 @@ def main(prompt, directory=DEFAULT_DIR, file=None):
                     prompt=prompt,
                 )
                 write_file(filename, filecode, directory)
+                generated_files_content += f"{directory}/{filename}\n"
+                generated_files_content += "\n"
+                generated_files_content += filecode
+                generated_files_content += "\n"
+
 
     except ValueError:
         print("Failed to parse result: " + result)
 
+# sometimes GPT-3.5 still returns some words around the content of the file
+# example:
+# # Makefile
+# ```makefile
+# contents
+# ````
+def get_code_from_string(input_string):
+    match = re.search(r'```[^\n]+?\n([\s\S]+?)\n```', input_string)
+    if match:
+        return match.group(1)
+    else:
+        return input_string
 
 def write_file(filename, filecode, directory):
     # Output the filename in blue color


### PR DESCRIPTION
### Changes:

1. `USE_FULL_PROJECT_PROMPT` env var. If enabled for each file generation prompt we will include all the files generated before
2. Sometimes GPT-3.5 still returns some words around the content of the file. This change extracts code from ``` blocks.
3. `OPENAI_DEFAULT_MODEL` and `OPENAI_DEFAULT_MAX_TOKENS` env vars added


The change is tested with `USE_FULL_PROJECT_PROMPT=True OPENAI_DEFAULT_MODEL=gpt-3.5-turbo-16k-0613 OPENAI_DEFAULT_MAX_TOKENS=9000` and `USE_FULL_PROJECT_PROMPT` makes a big change for small projects. My generated project is ~5000 tokens, so I'm safe to include full project files in the prompt.
