### PR TITLE
Add e2b deployment badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # smol developer
 
+<a href="https://e2b-prod.vercel.app/agent/smol-developer">
+<img src="https://e2b-prod.vercel.app/api/badge"/>
+</a>
+
 ***Human-centric & Coherent Whole Program Synthesis*** aka your own personal junior developer
 
 > [Build the thing that builds the thing!](https://twitter.com/swyx/status/1657578738345979905) a `smol dev` for every dev in every situation

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,10 @@
 # smol developer
 
-<a href="https://e2b-prod.vercel.app/agent/smol-developer">
-<img src="https://e2b-prod.vercel.app/api/badge"/>
+<a href="https://e2b-prod.vercel.app/agent/smol-developer" target="_blank" rel="noopener noreferrer">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://e2b-prod.vercel.app/api/badge_light">
+  <img alt="Deploy agent on e2b button" src="https://e2b-prod.vercel.app/api/badge"/>
+</picture>
 </a>
 
 ***Human-centric & Coherent Whole Program Synthesis*** aka your own personal junior developer

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # smol developer
 
-<a href="https://e2b-prod.vercel.app/agent/smol-developer" target="_blank" rel="noopener noreferrer">
+<a href="https://app.e2b.dev/agent/smol-developer" target="_blank" rel="noopener noreferrer">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://e2b-prod.vercel.app/api/badge_light">
-  <img alt="Deploy agent on e2b button" src="https://e2b-prod.vercel.app/api/badge"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://app.e2b.dev/api/badge_light">
+  <img alt="Deploy agent on e2b button" src="https://app.e2b.dev/api/badge"/>
 </picture>
 </a>
 


### PR DESCRIPTION
Hey Swyx, I added an agent deployment button to the readme. The button leads smol developer users to a setup where they can deploy their own smol developer on the [e2b cloud](https://e2b.dev/).