### PR TITLE
add the missing "model" param

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,4 +43,4 @@ if __name__ == "__main__":
 
     print(prompt)
         
-    main(prompt=prompt, generate_folder_path=args.generate_folder_path, debug=args.debug)
+    main(prompt=prompt, generate_folder_path=args.generate_folder_path, debug=args.debug, model=args.model)


### PR DESCRIPTION
Currently you can only run GPT4 because the main() function is NOT passing the `args.model` in main.py to smol_dev/main.py 

This is the cause behind the bug at https://github.com/smol-ai/developer/issues/25

By passing the args.model, now we can use models other than the default GPT4 model.