### PR TITLE
Point to correct readme file in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.3"
 description = "python module of smol developer"
 authors = ["swyx <swyx@dontemail.me>"]
 license = "MIT"
-readme = "README.md"
+readme = "readme.md"
 packages = [{ include = "smol_dev" }]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Without this, `poetry install` on a fresh clone of the repo fails:

```
(smol) ubuntu@ip-172-31-12-107:~/developer$ poetry install
Installing dependencies from lock file

Package operations: 24 installs, 2 updates, 0 removals

  • Installing frozenlist (1.3.3)
  • Installing multidict (6.0.4)
  • Installing sniffio (1.3.0)
  • Installing aiosignal (1.3.1)
  • Installing anyio (3.7.1)
  • Installing async-timeout (4.0.2)
  • Updating certifi (2023.7.22 -> 2023.5.7)
  • Installing h11 (0.14.0)
  • Installing hpack (4.0.0)
  • Installing hyperframe (6.0.1)
  • Installing typing-extensions (4.7.1)
  • Updating urllib3 (1.26.16 -> 2.0.3)
  • Installing yarl (1.9.2)
  • Installing aiohttp (3.8.4)
  • Installing h2 (4.1.0)
  • Installing priority (2.0.0)
  • Installing pydantic (1.10.11)
  • Installing starlette (0.27.0)
  • Installing tqdm (4.65.0)
  • Installing wsproto (1.2.0)
  • Installing fastapi (0.100.0)
  • Installing hypercorn (0.14.4)
  • Installing openai (0.27.8)
  • Installing agent-protocol (0.1.1)
  • Installing openai-function-call (0.0.5)
  • Installing tenacity (8.2.2)

[Errno 2] No such file or directory: '/home/ubuntu/developer/README.md'
```

Could also rename `readme.md` to `README.md`