### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere, Replicate Models - using litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{ include = "smol_dev" }]
 [tool.poetry.dependencies]
 python = "^3.11"
 openai = "^0.27.8"
+litellm = "^0.1.351"
 openai-function-call = "^0.0.5"
 tenacity = "^8.2.2"
 agent-protocol = "^0.1.1"

--- a/v0/debugger.py
+++ b/v0/debugger.py
@@ -54,6 +54,7 @@ def main(prompt, directory=DEFAULT_DIR, model="gpt-3.5-turbo"):
 )
 def generate_response(system_prompt, user_prompt, model="gpt-3.5-turbo", *args):
     import openai
+    from litellm import completion
 
     # Set up your OpenAI API credentials
     openai.api_key = os.environ["OPENAI_API_KEY"]
@@ -76,7 +77,7 @@ def generate_response(system_prompt, user_prompt, model="gpt-3.5-turbo", *args):
     }
 
     # Send the API request
-    response = openai.ChatCompletion.create(**params)
+    response = completion(**params)
 
     # Get the reply from the API response
     reply = response.choices[0]["message"]["content"]


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using litellm https://github.com/BerriAI/litellm

TLDR: `developer` gets:
- more models out of the box, everything litellm integrates with: https://litellm.readthedocs.io/en/latest/supported/ 
- instant integration of new models by modifying the `model` param (Easy to add models in the future, just change the model param)

Here's a sample of how it's used:
```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```