### PR TITLE
dev experience tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .env
 env
 __pycache__
-.vscode
 .idea
 /.idea/
 venv/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug main.py",
+      "type": "python",
+      "request": "launch",
+      "program": "main.py",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "args": ["--debug", "'a HTML/JS/CSS Tic Tac Toe Game'"],
+      "preLaunchTask": "poetry-install",
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python3"
+  }
+  

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        // Install or update all dependencies for all projects in the monrepo
+        {
+            "label": "poetry-install",
+            "type": "shell",
+            "command": "poetry install",
+            "problemMatcher": [], // Empty so users are not promted to select progress reporting
+        },
+    ]
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -166,6 +166,7 @@ files = [
 ]
 
 [package.dependencies]
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 
@@ -324,6 +325,20 @@ files = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.1.3"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "fastapi"
 version = "0.100.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -477,6 +492,7 @@ files = [
 h11 = "*"
 h2 = ">=3.1.0"
 priority = "*"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
 wsproto = ">=0.14.0"
 
 [package.extras]
@@ -740,12 +756,28 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-multipart"
@@ -806,6 +838,7 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.4.0,<5"
+typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
@@ -823,6 +856,17 @@ files = [
 
 [package.extras]
 doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
 
 [[package]]
 name = "tqdm"
@@ -975,5 +1019,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.11"
-content-hash = "c9659022543244cf9ad46ebfe70156f3f10cedacf2f67e38ec943b994f78ca5b"
+python-versions = ">=3.9, <4.0"
+content-hash = "0dd47e4699bb5c42a875f1fa3e93faf184a23aafaaff41be1e7544b90333c780"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,12 @@ readme = "readme.md"
 packages = [{ include = "smol_dev" }]
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9, <4.0"
 openai = "^0.27.8"
 openai-function-call = "^0.0.5"
 tenacity = "^8.2.2"
 agent-protocol = "^0.2.3"
+python-dotenv = "^1.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/readme.md
+++ b/readme.md
@@ -33,14 +33,15 @@ After the [successful initial v0 launch](https://twitter.com/swyx/status/1657578
 git clone https://github.com/smol-ai/developer.git
 cd developer
 poetry install # install dependencies. pip install poetry if you need
+poetry shell # activate virtualenv
 
 # run
-python main.py "a HTML/JS/CSS Tic Tac Toe Game" # defaults to gpt-4-0613
-# python main.py "a HTML/JS/CSS Tic Tac Toe Game" --model=gpt-3.5-turbo-0613
+python3 main.py "a HTML/JS/CSS Tic Tac Toe Game" # defaults to gpt-4-0613
+# python3 main.py "a HTML/JS/CSS Tic Tac Toe Game" --model=gpt-3.5-turbo-0613
 
 # other cli flags
-python main.py --prompt prompt.md # for longer prompts, move them into a markdown file
-python main.py --prompt prompt.md --debug True # for debugging
+python3 main.py --prompt prompt.md # for longer prompts, move them into a markdown file
+python3 main.py --prompt prompt.md --debug True # for debugging
 ```
 
 <details>
@@ -110,7 +111,7 @@ poetry run api
 ```
 or
 ```bash
-python smol_dev/api.py
+python3 smol_dev/api.py
 ```
 
 and then you can call the API using either the following commands:

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,8 @@ python3 main.py --prompt prompt.md # for longer prompts, move them into a markdo
 python3 main.py --prompt prompt.md --debug True # for debugging
 ```
 
+> Make sure to copy `.example.env` to `.env` and fill in your OpenAI API key
+
 <details>
   <summary>
 This lets you develop apps as a human in the loop, as per the original version of smol developer.
@@ -72,6 +74,8 @@ Loop until happiness is attained. Notice that AI is only used as long as it is a
 </details>
 
 In this way you can use your clone of this repo itself to prototype/develop your app.
+
+Alternatively, you can install and debug smol-developer in VS Code just by pressing F5 (using the preconfigured `launch.json`).
 
 ### In Library mode
 

--- a/smol_dev/prompts.py
+++ b/smol_dev/prompts.py
@@ -11,8 +11,13 @@ from tenacity import (
     wait_random_exponential,
 )
 import logging
+import os
+from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
+
+load_dotenv()
+openai.api_key = os.environ.get("OPENAI_API_KEY")
 
 
 SMOL_DEV_SYSTEM_PROMPT = """


### PR DESCRIPTION
Hi there! Was playing around with smol-dev (thinking of integrating with [Continue](https://github.com/continuedev/continue) soon : )) and came across a few bumps when setting up, so figured I might just share the changes I made for myself. Open to leaving out anything that you think doesn't belong, but here's what I edited:

- [ ] Add dependency for python-dotenv and use to load `OPENAI_API_KEY` env variable. Then in `prompts.py` added call to `load_dotenv` and set `openai.api_key` explicitly
- [ ] README: Replace `python` with `python3`, because there is a dependency on `python3` anyway so being specific can't hurt. In my case on Mac, `python3` works but `python` does not.
- [ ] README: Add step to activate the virtual environment with `poetry shell` (otherwise following the exact steps listed in "In Git Repo Mode" doesn't work)
- [ ] README: Add note to update `.example.env` and move to `.env`
- [ ] README: Add note about debugging in VS Code
- [ ] VS Code debugging pre-configuration: launch.json specifies how to debug `main.py`, and is setup to automatically make sure `poetry install` has been run prior (via tasks.json). And `settings.json` sets the default python interpreter to be the one from poetry.

*It's notable that I removed `.vscode` from the `.gitignore`, which means that someone with a prior settings.json mighta accidentally commit that if they don't notice, but there would first be merge conflicts to warn them and this file isn't meant to be secret, so should be okay.

If this is a lot for one PR let me know, happy to leave things out or split them up!