### PR TITLE
Fix bug in generating code for the same file

### DIFF
--- a/smol_dev/api.py
+++ b/smol_dev/api.py
@@ -37,7 +37,7 @@ async def _generate_file_paths(task: Task, step: Step) -> Step:
             f"Generate code for {file_path}",
             additional_properties={
                 "shared_deps": shared_deps,
-                "file_path": file_paths[-1],
+                "file_path": file_path,
             },
         )
 


### PR DESCRIPTION
The agent was generating the same file instead of looping over all files